### PR TITLE
Windows activate venv

### DIFF
--- a/lessons/beginners/venv-setup/index.md
+++ b/lessons/beginners/venv-setup/index.md
@@ -183,7 +183,8 @@ Nakonec virtuální prostředí aktivuj:
 {% call sidebyside(titles=['Unix', 'Windows']) %}
 $ source venv/bin/activate
 ---
-> venv\Scripts\activate
+> &powershell -ExecutionPolicy bypass
+> venv/Scripts/Activate.ps1
 {% endcall %}
 
 Po spuštění tohoto příkazu by se mělo na začátku příkazové řádky


### PR DESCRIPTION
Execution policy prevents activation of venv, so user need to bypass it (or permanently bypass it...) 
and also, name of the file to be activated changed to "Activate.ps1"